### PR TITLE
Remove chrome app

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -32,18 +32,6 @@ module.exports = {
         ],
       },
     },
-    {
-      resolve: `gatsby-plugin-manifest`,
-      options: {
-        name: `gatsby-starter-default`,
-        short_name: `starter`,
-        start_url: `/`,
-        background_color: `#663399`,
-        theme_color: `#663399`,
-        display: `minimal-ui`,
-        icon: `src/images/gatsby-icon.png`, // This path is relative to the root of the site.
-      },
-    },
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.dev/offline
     'gatsby-plugin-offline'


### PR DESCRIPTION
I noticed the gatsby starter comes with a chrome app, via [`gatsby-plugin-manifest`](https://www.gatsbyjs.org/packages/gatsby-plugin-manifest/?=chrome%20app). I don't see a need for this right now for my purposes, and it can potentially be perceived as annoying for users.

Removing for now.